### PR TITLE
Add missing 'needs' field to CI workflow

### DIFF
--- a/.changeset/old-clocks-fly.md
+++ b/.changeset/old-clocks-fly.md
@@ -1,0 +1,7 @@
+---
+"client": patch
+"common": patch
+"server": patch
+---
+
+missing needs

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -26,6 +26,7 @@ jobs:
         run: ./tools/check.sh
 
   ci:
+    needs: [check]
     if: |
       needs.check.outputs.deployable == 'true' &&
       github.event_name == 'pull_request' && 


### PR DESCRIPTION
Introduced a 'needs' declaration to the CI workflow in the 'deploy-main.yml' file which requires the 'check' job to finish successfully before commencing the 'ci' job. Also added an associated notes file under the changesets directory. This is to ensure the consistency and stability of our CI/CD pipeline.