### PR TITLE
Update package management tool in GitHub Actions

### DIFF
--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '19'
 
       - name: Install Dependencies
-        run: npm ci
+        run: yarn
 
       - name: Create Release Pull Request or Update Existing One
         uses: changesets/action@v1

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -1,10 +1,6 @@
 name: Changesets
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
   push:
     branches:
       - main


### PR DESCRIPTION
Changed the package management tool from npm to yarn in the .github/workflows/update-release-pr.yml. This change is due to the project's shift to use yarn over npm for more effective dependency management.